### PR TITLE
fix: prevent AssertionError when merging PRs

### DIFF
--- a/mcp_server/api_clients/github_client.py
+++ b/mcp_server/api_clients/github_client.py
@@ -539,11 +539,14 @@ class GitHubClient:
 
         # Merge the PR
         try:
-            result = pr.merge(
-                commit_title=commit_title,
-                commit_message=commit_message,
-                merge_method=merge_method,
-            )
+            # Only pass optional params if provided (PyGithub expects NotSet, not None)
+            merge_kwargs = {"merge_method": merge_method}
+            if commit_title is not None:
+                merge_kwargs["commit_title"] = commit_title
+            if commit_message is not None:
+                merge_kwargs["commit_message"] = commit_message
+
+            result = pr.merge(**merge_kwargs)
 
             return {
                 "merged": result.merged,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quickcall-integrations"
-version = "0.6.1"
+version = "0.6.2"
 description = "MCP server with developer integrations for Claude Code and Cursor"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- PyGithub's `merge()` expects `NotSet` for optional params, not `None`
- Use `**kwargs` to only pass `commit_title`/`commit_message` when provided
- Fixes `AssertionError: None` when merging PRs

## Test plan

- [x] Restart MCP server
- [x] Merge PR using `manage_prs(action="merge")`
- [x] Verified merge works without AssertionError